### PR TITLE
Settings: per-app cellular data, vpn and wifi restrictions

### DIFF
--- a/res/values/aosip_strings.xml
+++ b/res/values/aosip_strings.xml
@@ -204,4 +204,12 @@
     <!-- Notification log -->
     <string name="notification_log_summary">Show notifications history log</string>
 
+    <!-- Per-app data restrictions -->
+    <string name="data_usage_app_restrict_data">Cellular data</string>
+    <string name="data_usage_app_restrict_data_summary">Enable usage of cellular data</string>
+    <string name="data_usage_app_restrict_vpn">VPN data</string>
+    <string name="data_usage_app_restrict_vpn_summary">Enable usage of VPN data</string>
+    <string name="data_usage_app_restrict_wifi">Wi\u2011Fi data</string>
+    <string name="data_usage_app_restrict_wifi_summary">Enable usage of Wi\u2011Fi data</string>
+
 </resources>

--- a/res/xml/app_data_usage.xml
+++ b/res/xml/app_data_usage.xml
@@ -56,11 +56,26 @@
             android:title="@string/data_usage_app_settings" />
 
         <com.android.settingslib.RestrictedSwitchPreference
+            android:key="restrict_wlan"
+            android:title="@string/data_usage_app_restrict_wifi"
+            android:summary="@string/data_usage_app_restrict_wifi_summary" />
+
+        <com.android.settingslib.RestrictedSwitchPreference
+            android:key="restrict_data"
+            android:title="@string/data_usage_app_restrict_data"
+            android:summary="@string/data_usage_app_restrict_data_summary" />
+
+        <com.android.settingslib.RestrictedSwitchPreference
             android:key="restrict_background"
             android:title="@string/data_usage_app_restrict_background"
             android:summary="@string/data_usage_app_restrict_background_summary"
             settings:useAdditionalSummary="true"
             settings:restrictedSwitchSummary="@string/disabled_by_admin" />
+
+        <com.android.settingslib.RestrictedSwitchPreference
+            android:key="restrict_vpn"
+            android:title="@string/data_usage_app_restrict_vpn"
+            android:summary="@string/data_usage_app_restrict_vpn_summary" />
 
         <com.android.settingslib.RestrictedSwitchPreference
             android:key="unrestricted_data_saver"

--- a/src/com/android/settings/datausage/AppDataUsage.java
+++ b/src/com/android/settings/datausage/AppDataUsage.java
@@ -15,6 +15,9 @@
 package com.android.settings.datausage;
 
 import static android.net.NetworkPolicyManager.POLICY_REJECT_METERED_BACKGROUND;
+import static android.net.NetworkPolicyManager.POLICY_REJECT_ON_DATA;
+import static android.net.NetworkPolicyManager.POLICY_REJECT_ON_VPN;
+import static android.net.NetworkPolicyManager.POLICY_REJECT_ON_WLAN;
 
 import android.app.Activity;
 import android.app.settings.SettingsEnums;
@@ -23,6 +26,7 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
+import android.net.NetworkPolicyManager;
 import android.net.NetworkTemplate;
 import android.os.Bundle;
 import android.os.UserHandle;
@@ -70,6 +74,9 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
     private static final String KEY_BACKGROUND_USAGE = "background_usage";
     private static final String KEY_APP_SETTINGS = "app_settings";
     private static final String KEY_RESTRICT_BACKGROUND = "restrict_background";
+    private static final String KEY_RESTRICT_DATA = "restrict_data";
+    private static final String KEY_RESTRICT_VPN = "restrict_vpn";
+    private static final String KEY_RESTRICT_WLAN = "restrict_wlan";
     private static final String KEY_APP_LIST = "app_list";
     private static final String KEY_CYCLE = "cycle";
     private static final String KEY_UNRESTRICTED_DATA = "unrestricted_data_saver";
@@ -84,6 +91,9 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
     private Preference mBackgroundUsage;
     private Preference mAppSettings;
     private RestrictedSwitchPreference mRestrictBackground;
+    private RestrictedSwitchPreference mRestrictData;
+    private RestrictedSwitchPreference mRestrictVpn;
+    private RestrictedSwitchPreference mRestrictWlan;
     private PreferenceCategory mAppList;
 
     private Drawable mIcon;
@@ -96,6 +106,7 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
     private List<NetworkCycleDataForUid> mUsageData;
     @VisibleForTesting
     NetworkTemplate mTemplate;
+    private NetworkPolicyManager mPolicyManager;
     private AppItem mAppItem;
     private Intent mAppSettingsIntent;
     private SpinnerPreference mCycle;
@@ -112,6 +123,7 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
         mPackageManager = getPackageManager();
         final Bundle args = getArguments();
 
+        mPolicyManager = NetworkPolicyManager.from(getContext());
         mAppItem = (args != null) ? (AppItem) args.getParcelable(ARG_APP_ITEM) : null;
         mTemplate = (args != null) ? (NetworkTemplate) args.getParcelable(ARG_NETWORK_TEMPLATE)
                 : null;
@@ -156,6 +168,9 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
                 mLabel = uidDetail.label;
                 removePreference(KEY_UNRESTRICTED_DATA);
                 removePreference(KEY_RESTRICT_BACKGROUND);
+                removePreference(KEY_RESTRICT_DATA);
+                removePreference(KEY_RESTRICT_VPN);
+                removePreference(KEY_RESTRICT_WLAN);
             } else {
                 if (mPackages.size() != 0) {
                     try {
@@ -169,6 +184,12 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
                 }
                 mRestrictBackground = findPreference(KEY_RESTRICT_BACKGROUND);
                 mRestrictBackground.setOnPreferenceChangeListener(this);
+                mRestrictData = findPreference(KEY_RESTRICT_DATA);
+                mRestrictData.setOnPreferenceChangeListener(this);
+                mRestrictVpn = findPreference(KEY_RESTRICT_VPN);
+                mRestrictVpn.setOnPreferenceChangeListener(this);
+                mRestrictWlan = findPreference(KEY_RESTRICT_WLAN);
+                mRestrictWlan.setOnPreferenceChangeListener(this);
                 mUnrestrictedData = findPreference(KEY_UNRESTRICTED_DATA);
                 mUnrestrictedData.setOnPreferenceChangeListener(this);
             }
@@ -209,6 +230,9 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
             removePreference(KEY_UNRESTRICTED_DATA);
             removePreference(KEY_APP_SETTINGS);
             removePreference(KEY_RESTRICT_BACKGROUND);
+            removePreference(KEY_RESTRICT_DATA);
+            removePreference(KEY_RESTRICT_VPN);
+            removePreference(KEY_RESTRICT_WLAN);
             removePreference(KEY_APP_LIST);
         }
     }
@@ -236,6 +260,18 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
     public boolean onPreferenceChange(Preference preference, Object newValue) {
         if (preference == mRestrictBackground) {
             mDataSaverBackend.setIsBlacklisted(mAppItem.key, mPackageName, !(Boolean) newValue);
+            updatePrefs();
+            return true;
+        } else if (preference == mRestrictData) {
+            setAppRestrictData(!(Boolean) newValue);
+            updatePrefs();
+            return true;
+        } else if (preference == mRestrictVpn) {
+            setAppRestrictVpn(!(Boolean) newValue);
+            updatePrefs();
+            return true;
+        } else if (preference == mRestrictWlan) {
+            setAppRestrictWlan(!(Boolean) newValue);
             updatePrefs();
             return true;
         } else if (preference == mUnrestrictedData) {
@@ -268,7 +304,8 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
 
     @VisibleForTesting
     void updatePrefs() {
-        updatePrefs(getAppRestrictBackground(), getUnrestrictData());
+        updatePrefs(getAppRestrictBackground(), getUnrestrictData(),
+                getAppRestrictData(), getAppRestrictVpn(), getAppRestrictWlan());
     }
 
     @VisibleForTesting
@@ -276,21 +313,38 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
         return new UidDetailProvider(mContext);
     }
 
-    private void updatePrefs(boolean restrictBackground, boolean unrestrictData) {
+    private void updatePrefs(boolean restrictBackground, boolean unrestrictData,
+            boolean restrictData, boolean restrictVpn, boolean restrictWlan) {
         final EnforcedAdmin admin = RestrictedLockUtilsInternal.checkIfMeteredDataRestricted(
                 mContext, mPackageName, UserHandle.getUserId(mAppItem.key));
         if (mRestrictBackground != null) {
-            mRestrictBackground.setChecked(!restrictBackground);
+            if (restrictData) {
+                mRestrictBackground.setEnabled(false);
+                mRestrictBackground.setChecked(false);
+            } else {
+                mRestrictBackground.setEnabled(true);
+                mRestrictBackground.setChecked(!restrictBackground);
+            }
             mRestrictBackground.setDisabledByAdmin(admin);
         }
+        if (mRestrictData != null) {
+            mRestrictData.setChecked(!restrictData);
+        }
+        if (mRestrictVpn != null) {
+            mRestrictVpn.setChecked(!restrictVpn);
+        }
+        if (mRestrictWlan != null) {
+            mRestrictWlan.setChecked(!restrictWlan);
+        }
         if (mUnrestrictedData != null) {
-            if (restrictBackground) {
-                mUnrestrictedData.setVisible(false);
+            if (restrictData || restrictBackground) {
+                mUnrestrictedData.setEnabled(false);
+                mUnrestrictedData.setChecked(false);
             } else {
-                mUnrestrictedData.setVisible(true);
+                mUnrestrictedData.setEnabled(true);
                 mUnrestrictedData.setChecked(unrestrictData);
-                mUnrestrictedData.setDisabledByAdmin(admin);
             }
+            mUnrestrictedData.setDisabledByAdmin(admin);
         }
     }
 
@@ -323,9 +377,19 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
     }
 
     private boolean getAppRestrictBackground() {
-        final int uid = mAppItem.key;
-        final int uidPolicy = services.mPolicyManager.getUidPolicy(uid);
-        return (uidPolicy & POLICY_REJECT_METERED_BACKGROUND) != 0;
+        return getAppRestriction(POLICY_REJECT_METERED_BACKGROUND);
+    }
+
+    private boolean getAppRestrictData() {
+        return getAppRestriction(POLICY_REJECT_ON_DATA);
+    }
+
+    private boolean getAppRestrictVpn() {
+        return getAppRestriction(POLICY_REJECT_ON_VPN);
+    }
+
+    private boolean getAppRestrictWlan() {
+        return getAppRestriction(POLICY_REJECT_ON_WLAN);
     }
 
     private boolean getUnrestrictData() {
@@ -333,6 +397,33 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
             return mDataSaverBackend.isWhitelisted(mAppItem.key);
         }
         return false;
+    }
+
+    private boolean getAppRestriction(int policy) {
+        final int uid = mAppItem.key;
+        final int uidPolicy = services.mPolicyManager.getUidPolicy(uid);
+        return (uidPolicy & policy) != 0;
+    }
+
+    private void setAppRestrictData(boolean restrict) {
+        setAppRestriction(POLICY_REJECT_ON_DATA, restrict);
+    }
+
+    private void setAppRestrictVpn(boolean restrict) {
+        setAppRestriction(POLICY_REJECT_ON_VPN, restrict);
+    }
+
+    private void setAppRestrictWlan(boolean restrict) {
+        setAppRestriction(POLICY_REJECT_ON_WLAN, restrict);
+    }
+
+    private void setAppRestriction(int policy, boolean restrict) {
+        final int uid = mAppItem.key;
+        if (restrict) {
+            mPolicyManager.addUidPolicy(uid, policy);
+        } else {
+            mPolicyManager.removeUidPolicy(uid, policy);
+        }
     }
 
     @Override
@@ -466,14 +557,16 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
     @Override
     public void onWhitelistStatusChanged(int uid, boolean isWhitelisted) {
         if (mAppItem.uids.get(uid, false)) {
-            updatePrefs(getAppRestrictBackground(), isWhitelisted);
+            updatePrefs(getAppRestrictBackground(), isWhitelisted,
+                    getAppRestrictData(), getAppRestrictVpn(), getAppRestrictWlan());
         }
     }
 
     @Override
     public void onBlacklistStatusChanged(int uid, boolean isBlacklisted) {
         if (mAppItem.uids.get(uid, false)) {
-            updatePrefs(isBlacklisted, getUnrestrictData());
+            updatePrefs(isBlacklisted, getUnrestrictData(),
+                    getAppRestrictData(), getAppRestrictVpn(), getAppRestrictWlan());
         }
     }
 }


### PR DESCRIPTION
*) Add options to disable all cellular, vpn and wifi data
   in app data usage settings.

*) Disable the existing background data and unrestricted
   data usage options when all cellular data access is
   disabled.

*) The vpn data option can be selected independently from state of
   all Wi-Fi and mobile data access enable/disable.

*) Prevent DataSaverBackend from overwriting uid policies

This is a replacement for the appops menu based cell/wifi data
restriction settings in cm-13.0:
Author: Danesh M <daneshm90@gmail.com>
Date:   Mon Mar 7 15:17:59 2016 -0800
    Settings : Add per app internet/data control
    CYAN-3976
    CRACKLING-834
    Change-Id: I13192df837c057b5cadde8f31532e12daaf3c1b0

Change-Id: Ic087c27a5ed0bdb84bb8f297c425c6bcbffec848
(cherry picked from commit d4a2eea698cbc4636a635d60f2a52ec1bbc36ba2)